### PR TITLE
Robert suggestions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <name>My OSS Project</name>
@@ -96,7 +97,24 @@
       <artifactId>jackson-databind</artifactId>
     <version>2.14.0</version>
   </dependency>
-
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>runtime</scope>
+    </dependency>
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <log4j.version>2.17.1</log4j.version>
+    <flink.version>1.16.0</flink.version>
   </properties>
 
   <name>My OSS Project</name>
@@ -79,12 +80,17 @@
 	<dependency>
 	    <groupId>org.apache.flink</groupId>
 	    <artifactId>flink-java</artifactId>
-	    <version>1.16.0</version>
+	    <version>${flink.version}</version>
 	</dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-runtime-web</artifactId>
+      <version>${flink.version}</version>
+    </dependency>
 	<dependency>
 	    <groupId>org.apache.flink</groupId>
 	    <artifactId>flink-clients</artifactId>
-	   	<version>1.16.0</version>
+	   	<version>${flink.version}</version>
 	</dependency>
 	<dependency>
       <groupId>com.ververica</groupId>

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,7 @@
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n


### PR DESCRIPTION
Changelog:
- add log4j: This will give you the Flink (and dbz) log output for your personal enjoyment. I like seeing what the engine does.
- Refactor MapFunction to use Operator State as described in https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/fault-tolerance/state/#using-operator-state and https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/CheckpointedFunction.java#L28-L148

I have to admit I was actually not aware that `ValueState` is not available for as OperatorState, but I guess it makes sense in the context of rescaling. We have a special case here because our operators are not parallel.

I haven't checked if my change causes incorrect results 🙈 